### PR TITLE
Fixing typo in favorites tag

### DIFF
--- a/content/recipes/skillet-spanakopita.md
+++ b/content/recipes/skillet-spanakopita.md
@@ -2,7 +2,7 @@
 title: "Skillet Spanakopita"
 date: 2020-11-09T16:32:09-07:00
 draft: false
-tags: ["entree", "favorite", "Greek"]
+tags: ["entree", "favorites", "Greek"]
 author: ["Mark Bittman"]
 cook: "45 minutes"
 ---

--- a/public/author/family/index.html
+++ b/public/author/family/index.html
@@ -3,7 +3,7 @@
 <html lang="en-us">
   <head>
     
-    <title>family // Brayden&#39;s Recipes</title>
+    <title>Family // Brayden&#39;s Recipes</title>
     <meta charset="utf-8" />
     <meta name="generator" content="Hugo 0.61.0" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/public/author/family/index.xml
+++ b/public/author/family/index.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>family on Brayden&#39;s Recipes</title>
+    <title>Family on Brayden&#39;s Recipes</title>
     <link>https://bstreete.github.io/public/author/family/</link>
-    <description>Recent content in family on Brayden&#39;s Recipes</description>
+    <description>Recent content in Family on Brayden&#39;s Recipes</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <lastBuildDate>Sun, 05 Apr 2020 07:52:09 -0700</lastBuildDate>

--- a/public/author/index.html
+++ b/public/author/index.html
@@ -184,7 +184,7 @@
       
         <li class="posts-list-item">
             <a class="posts-list-item-title" href="https://bstreete.github.io/public/author/family/">
-              family
+              Family
             </a> 
             26
         </li>

--- a/public/author/index.xml
+++ b/public/author/index.xml
@@ -93,7 +93,7 @@
     </item>
     
     <item>
-      <title>family</title>
+      <title>Family</title>
       <link>https://bstreete.github.io/public/author/family/</link>
       <pubDate>Sun, 05 Apr 2020 07:52:09 -0700</pubDate>
       

--- a/public/recipes/skillet-spanakopita/index.html
+++ b/public/recipes/skillet-spanakopita/index.html
@@ -137,7 +137,7 @@
             
                 
                 
-                    <a class="tag" href="https://bstreete.github.io/public/tags/favorite/">favorite</a>
+                    <a class="tag" href="https://bstreete.github.io/public/tags/favorites/">favorites</a>
                 
             
                 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -18,7 +18,7 @@
   </url>
   
   <url>
-    <loc>https://bstreete.github.io/public/tags/favorite/</loc>
+    <loc>https://bstreete.github.io/public/tags/favorites/</loc>
     <lastmod>2020-11-09T16:32:09-07:00</lastmod>
   </url>
   
@@ -209,11 +209,6 @@
   
   <url>
     <loc>https://bstreete.github.io/public/author/best-ever-curry-cookbook/</loc>
-    <lastmod>2020-03-29T09:06:35-07:00</lastmod>
-  </url>
-  
-  <url>
-    <loc>https://bstreete.github.io/public/tags/favorites/</loc>
     <lastmod>2020-03-29T09:06:35-07:00</lastmod>
   </url>
   

--- a/public/tags/favorites/index.html
+++ b/public/tags/favorites/index.html
@@ -214,6 +214,13 @@
         </li>
       
         <li class="posts-list-item">
+          <a class="posts-list-item-title" href="https://bstreete.github.io/public/recipes/skillet-spanakopita/">Skillet Spanakopita</a>
+          <span class="posts-list-item-description">
+            Uploaded Nov 9, 2020
+          </span>
+        </li>
+      
+        <li class="posts-list-item">
           <a class="posts-list-item-title" href="https://bstreete.github.io/public/recipes/black-bean-soup/">Slow Cooker Black Bean Soup</a>
           <span class="posts-list-item-description">
             Uploaded Dec 23, 2019

--- a/public/tags/favorites/index.xml
+++ b/public/tags/favorites/index.xml
@@ -6,10 +6,20 @@
     <description>Recent content in favorites on Brayden&#39;s Recipes</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sun, 29 Mar 2020 09:06:35 -0700</lastBuildDate>
+    <lastBuildDate>Mon, 09 Nov 2020 16:32:09 -0700</lastBuildDate>
     
 	<atom:link href="https://bstreete.github.io/public/tags/favorites/index.xml" rel="self" type="application/rss+xml" />
     
+    
+    <item>
+      <title>Skillet Spanakopita</title>
+      <link>https://bstreete.github.io/public/recipes/skillet-spanakopita/</link>
+      <pubDate>Mon, 09 Nov 2020 16:32:09 -0700</pubDate>
+      
+      <guid>https://bstreete.github.io/public/recipes/skillet-spanakopita/</guid>
+      <description>Taken from How to Cook Everything Fast, page 468-469
+Ingredients  10 to 12 sheets of phyllo dough 3 tablespoons olive oil 4 scallions two 10-ounce bags of spinach salt and pepper 2 eggs 6 ounces feta cheese (1 1/2 cups crumbled) 1 teaspoon dried dill 1/4 teaspoon nutmeg 4 tablespoons butter  Directions  Remove phyllo from freezer. Heat oven to 350 degrees. Put olive oil in a medium ovenproof skillet over low heat.</description>
+    </item>
     
     <item>
       <title>Tricolour Pulao</title>

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -148,17 +148,10 @@
         </li>
       
         <li class="posts-list-item">
-            <a class="posts-list-item-title" href="https://bstreete.github.io/public/tags/favorite/">
-              favorite
-            </a> 
-            1
-        </li>
-      
-        <li class="posts-list-item">
             <a class="posts-list-item-title" href="https://bstreete.github.io/public/tags/favorites/">
               favorites
             </a> 
-            19
+            20
         </li>
       
         <li class="posts-list-item">

--- a/public/tags/index.xml
+++ b/public/tags/index.xml
@@ -21,11 +21,11 @@
     </item>
     
     <item>
-      <title>favorite</title>
-      <link>https://bstreete.github.io/public/tags/favorite/</link>
+      <title>favorites</title>
+      <link>https://bstreete.github.io/public/tags/favorites/</link>
       <pubDate>Mon, 09 Nov 2020 16:32:09 -0700</pubDate>
       
-      <guid>https://bstreete.github.io/public/tags/favorite/</guid>
+      <guid>https://bstreete.github.io/public/tags/favorites/</guid>
       <description></description>
     </item>
     
@@ -134,15 +134,6 @@
       <pubDate>Sun, 05 Apr 2020 07:39:03 -0700</pubDate>
       
       <guid>https://bstreete.github.io/public/tags/german/</guid>
-      <description></description>
-    </item>
-    
-    <item>
-      <title>favorites</title>
-      <link>https://bstreete.github.io/public/tags/favorites/</link>
-      <pubDate>Sun, 29 Mar 2020 09:06:35 -0700</pubDate>
-      
-      <guid>https://bstreete.github.io/public/tags/favorites/</guid>
       <description></description>
     </item>
     


### PR DESCRIPTION
Addressing typo in Skillet Spanakopita page which incorrectly used the `favorite` instead of `favorites` tag. 